### PR TITLE
Fix "ValidationException" error during fivem server creation

### DIFF
--- a/egg-five-m.json
+++ b/egg-five-m.json
@@ -32,7 +32,7 @@
             "name": "fivem license",
             "description": "Required to start the service. Get your keys at https:\/\/keymaster.fivem.net\/",
             "env_variable": "FIVEM_LICENSE",
-            "default_value": "",
+            "default_value": "place-key-here",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:32"


### PR DESCRIPTION
Default fivem_license value ("") conflicts with rules ("required") during fivem server creation.
![image](https://user-images.githubusercontent.com/62807269/126891078-65e4036b-edd1-4a0d-8e01-c52228d7ef92.png)
